### PR TITLE
Remove docker container after ./run is excuted

### DIFF
--- a/run
+++ b/run
@@ -6,4 +6,4 @@ source bash/execute.sh
 command=$(argsToCommand "$@")
 command=$(escapeDoubleQuoates "$command")
 
-execute docker-compose run --user=node -v $PWD:/home/node/app api /bin/bash -c "cd /home/node/app && $command"
+execute docker-compose run --rm --user=node -v $PWD:/home/node/app api /bin/bash -c "cd /home/node/app && $command"


### PR DESCRIPTION
After run a script from docker container using ./run script,
the container is finished but still showing as finished container.
To clean these --rm is added so the container will be removed after the
script ran